### PR TITLE
chore: add japanese version

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,9 +1,9 @@
-# Copilot Instructions for Project Structure Workflow
+# Copilotプロジェクト構造ワークフローの指示
 
-Just some sample instructions that should stay in place...
+いくつかのサンプル指示がそのまま残ります...
 
 <!-- BEGIN GENERATED CONTENT -->
-## Package (js): `.`
+## パッケージ (js): `.`
 
 - bin/
   - cli.js
@@ -131,7 +131,7 @@ Just some sample instructions that should stay in place...
     - anotherFunction
     - sampleFunction
 
-## Package (js): `sample-js-project`
+## パッケージ (js): `sample-js-project`
 
 - index.js
   - sampleVariable
@@ -139,7 +139,7 @@ Just some sample instructions that should stay in place...
   - anotherFunction
   - sampleFunction
 
-## Package (js): `sample-ts-project`
+## パッケージ (js): `sample-ts-project`
 
 - index.ts
   - sampleVariable
@@ -147,7 +147,7 @@ Just some sample instructions that should stay in place...
   - anotherFunction
   - sampleFunction
 
-## Package (py): `sample-python-project`
+## パッケージ (py): `sample-python-project`
 
 - main.py
   - SampleClass


### PR DESCRIPTION
Translate the Copilot instructions to Japanese.

* Change the title to "Copilotプロジェクト構造ワークフローの指示"
* Translate the sample instructions to "いくつかのサンプル指示がそのまま残ります..."
* Translate "Package (js): `.`" to "パッケージ (js): `.`"
* Translate "Package (js): `sample-js-project`" to "パッケージ (js): `sample-js-project`"
* Translate "Package (js): `sample-ts-project`" to "パッケージ (js): `sample-ts-project`"
* Translate "Package (py): `sample-python-project`" to "パッケージ (py): `sample-python-project`"

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/dai/settings-global/pull/1?shareId=e04facd7-b96d-44bf-a3f0-5b16883bcdbe).